### PR TITLE
Fix CI workflow imports

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.x'
 
       - name: Install dependencies
         run: |
@@ -17,5 +17,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}
         run: |
-          pytest
+          python -m pytest


### PR DESCRIPTION
## Summary
- fix imports in GitHub Actions by running tests via `python -m pytest`
- allow latest Python 3.x version
- set `PYTHONPATH` so tests find project modules

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eb93e1b048328af51b70fe91efda0