### PR TITLE
Add optional rent growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,10 @@ The application will be available at `http://localhost:5000`.
 ## Contributing
 
 Please read [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute to this project.
+
+### Rent Growth
+
+The **Rent Growth % (optional)** field allows you to model annual rent escalation.
+Enter a yearly percentage (e.g., `3` for 3% growth). If left at `0`, rents remain
+flat. When a rate is provided, rents compound each year and all cash flow metrics,
+ROI, IRR, payback period and charts will reflect the increasing income.

--- a/report_generator.py
+++ b/report_generator.py
@@ -65,11 +65,16 @@ def _generate_charts(calc: FinancialCalculator, scenarios: Dict[str, Any], img_d
     os.makedirs(img_dir, exist_ok=True)
     charts = []
     years = list(range(1, calc.holding_period + 1))
-    cumulative = {
-        'Conservative': [scenarios['conservative']['annual_cash_flow'] * y for y in years],
-        'Base': [scenarios['base']['annual_cash_flow'] * y for y in years],
-        'Optimistic': [scenarios['optimistic']['annual_cash_flow'] * y for y in years],
-    }
+    cumulative = {}
+    for key, name in [('conservative', 'Conservative'), ('base', 'Base'), ('optimistic', 'Optimistic')]:
+        total = 0
+        cumulative[name] = []
+        for cf in scenarios[key]['cash_flow_schedule']:
+            total += cf
+            cumulative[name].append(total)
+        # pad to full length if needed
+        if len(cumulative[name]) < len(years):
+            cumulative[name].extend([total] * (len(years) - len(cumulative[name])))
 
     fig, ax = plt.subplots(figsize=(6, 3))
     for name, values in cumulative.items():

--- a/templates/index.html
+++ b/templates/index.html
@@ -69,7 +69,13 @@
                             <input type="range" class="form-control-range" id="occupancy_rate" name="occupancy_rate" min="70" max="100" value="95">
                             <span id="occupancy_value">95%</span>
                         </div>
-                        
+
+                        <div class="form-group">
+                            <label for="rent_growth">Rent Growth % (optional)</label>
+                            <input type="number" class="form-control" id="rent_growth" name="rent_growth" value="0" step="0.1">
+                            <small class="form-text text-muted">Annual rent escalation rate</small>
+                        </div>
+
                         <div class="form-group">
                             <label for="hoa_fees_annual">HOA Fees (Annual, SAR)</label>
                             <input type="text" class="form-control currency-input" id="hoa_fees_annual" name="hoa_fees_annual" value="0" data-value="0">

--- a/tests/test_financial_calculator.py
+++ b/tests/test_financial_calculator.py
@@ -18,3 +18,32 @@ def test_monthly_payment():
     calc = FinancialCalculator(100000, 20000, 30, 5.0, 1500, 100)
     payment = calc.get_monthly_payment()
     assert payment == pytest.approx(429.46, abs=0.1)
+
+
+def test_rent_growth_escalates_cash_flow():
+    growth_calc = FinancialCalculator(
+        property_price=100000,
+        down_payment=20000,
+        loan_term=30,
+        interest_rate=5.0,
+        base_monthly_rent=1000,
+        occupancy_rate=100,
+        holding_period=3,
+        rent_growth=5
+    )
+    flat_calc = FinancialCalculator(
+        property_price=100000,
+        down_payment=20000,
+        loan_term=30,
+        interest_rate=5.0,
+        base_monthly_rent=1000,
+        occupancy_rate=100,
+        holding_period=3,
+        rent_growth=0
+    )
+
+    growth_schedule = growth_calc.get_cash_flow_schedule()
+    flat_schedule = flat_calc.get_cash_flow_schedule()
+
+    assert growth_schedule[1] > flat_schedule[1]
+    assert growth_schedule[2] > growth_schedule[1]


### PR DESCRIPTION
## Summary
- support rent growth percentage throughout financial calculations
- display new `Rent Growth % (optional)` input in the dashboard
- update advanced metrics, charts, and exports for escalating rents
- document the feature in README
- add regression test for rent escalation logic

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870288016cc8328875db3c32187221c