### PR TITLE
Enhance mobile support

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -45,6 +45,11 @@ body {
     z-index: 100;
 }
 
+/* Sidebar Toggle Button */
+.sidebar-toggle {
+    display: none;
+}
+
 .sidebar-content h3,
 .sidebar-content h4 {
     color: #ffffff;
@@ -503,7 +508,7 @@ body {
         min-height: auto;
         padding: 1rem;
     }
-    
+
     .main-content {
         padding: 1rem;
     }
@@ -559,14 +564,29 @@ body {
 
 /* Responsive adjustments */
 @media (max-width: 768px) {
-    .sidebar {
-        position: relative;
-        width: 100%;
-        height: auto;
-        min-height: auto;
+    .sidebar-toggle {
+        display: block;
+        position: fixed;
+        top: 1rem;
+        left: 1rem;
+        z-index: 2000;
     }
-    
+
+    #sidebar {
+        position: fixed;
+        width: 80%;
+        max-width: 300px;
+        height: 100vh;
+        transform: translateX(-100%);
+        transition: transform 0.3s ease;
+    }
+
+    #sidebar.open {
+        transform: translateX(0);
+    }
+
     .main-content {
         margin-left: 0;
+        padding: 1rem;
     }
 }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -10,6 +10,14 @@ document.addEventListener('DOMContentLoaded', function() {
     const downPaymentPercentageValue = document.getElementById('down_payment_percentage_value');
     const downPaymentAmount = document.getElementById('down_payment_amount');
     const propertyPriceInput = document.getElementById('property_price');
+    const sidebarToggle = document.getElementById('sidebarToggle');
+    const sidebar = document.getElementById('sidebar');
+
+    if (sidebarToggle) {
+        sidebarToggle.addEventListener('click', function() {
+            sidebar.classList.toggle('open');
+        });
+    }
 
     // Initialize currency input formatting
     initializeCurrencyInputs();

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,10 +10,13 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 </head>
 <body>
+    <button class="btn btn-primary sidebar-toggle d-md-none" id="sidebarToggle">
+        <i class="fas fa-bars"></i>
+    </button>
     <div class="container-fluid p-0">
         <div class="row g-0">
             <!-- Sidebar -->
-            <div class="col-md-3 sidebar">
+            <div class="col-md-3 sidebar" id="sidebar">
                 <div class="sidebar-content">
                     <h3><i class="fas fa-home"></i> Property Details</h3>
                     <form id="calculatorForm">


### PR DESCRIPTION
## Summary
- add a sidebar toggle for small screens
- slide sidebar in/out on mobile via new CSS rules
- hook up the toggle button in JavaScript

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687030a58a648328a6871e59afe3b2d6