### PR TITLE
Simplify inputs and restore dashboard KPIs

### DIFF
--- a/templates/analyzer_form.html
+++ b/templates/analyzer_form.html
@@ -26,11 +26,6 @@
           <input type="number" class="form-control" name="down_payment" required>
         </div>
         <div class="col-md-3">
-          <label class="form-label">Closing Costs</label>
-          <input type="number" class="form-control" name="closing_costs" value="0">
-        </div>
-
-        <div class="col-md-3">
           <label class="form-label">Interest Rate (%)</label>
           <input type="number" step="0.01" class="form-control" name="interest_rate" required>
         </div>
@@ -42,41 +37,6 @@
           <label class="form-label">Annual Rent</label>
           <input type="number" class="form-control" name="annual_rent" required>
         </div>
-        <div class="col-md-3">
-          <label class="form-label">Rent Growth % (y/y)</label>
-          <input type="number" step="0.1" class="form-control" name="rent_growth" value="0">
-        </div>
-
-        <div class="col-md-3">
-          <label class="form-label">Vacancy Rate %</label>
-          <input type="number" step="0.1" class="form-control" name="vacancy_rate" value="5">
-        </div>
-        <div class="col-md-3">
-          <label class="form-label">Operating Expenses % (of rent)</label>
-          <input type="number" step="0.1" class="form-control" name="opex_percent" value="30">
-        </div>
-        <div class="col-md-3">
-          <label class="form-label">Annual Insurance</label>
-          <input type="number" class="form-control" name="insurance" value="0">
-        </div>
-        <div class="col-md-3">
-          <label class="form-label">HOA / Fees</label>
-          <input type="number" class="form-control" name="hoa" value="0">
-        </div>
-
-        <div class="col-md-3">
-          <label class="form-label">Rehab (one-time)</label>
-          <input type="number" class="form-control" name="rehab_cost" value="0">
-        </div>
-        <div class="col-md-3">
-          <label class="form-label">Exit Year</label>
-          <input type="number" class="form-control" name="exit_year" value="10">
-        </div>
-        <div class="col-md-3">
-          <label class="form-label">Exit Cap Rate %</label>
-          <input type="number" step="0.1" class="form-control" name="exit_cap_rate" value="6">
-        </div>
-
       </div>
     </div>
   </div>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -10,6 +10,7 @@
 <div class="row g-3 mb-3">
   {% for kpi in [
     ('Cash Flow / Mo', metrics.monthly_cash_flow),
+    ('Cash Flow / Yr', metrics.annual_cash_flow),
     ('Cash-on-Cash', metrics.cash_on_cash),
     ('IRR', metrics.irr),
     ('Cap Rate', metrics.cap_rate),
@@ -22,7 +23,13 @@
     <div class="card shadow-sm h-100">
       <div class="card-body">
         <div class="text-secondary">{{ kpi[0] }}</div>
-        <div class="fs-4 fw-bold">
+        {% set cls = '' %}
+        {% if 'Cash Flow' in kpi[0] or 'NOI' in kpi[0] %}
+          {% set cls = 'text-danger' if kpi[1] < 0 else 'text-success' %}
+        {% elif kpi[0] == 'DSCR' %}
+          {% set cls = 'text-danger' if kpi[1] < 1 else 'text-success' %}
+        {% endif %}
+        <div class="fs-4 fw-bold {{ cls }}">
           {% if 'Rate' in kpi[0] or 'ROI' in kpi[0] or 'Cash-on-Cash' in kpi[0] or 'IRR' in kpi[0] %}
             {{ (kpi[1] * 100) | round(1) }}%
           {% elif 'Payback' in kpi[0] %}
@@ -79,9 +86,9 @@
           <td>{{ r.year }}</td>
           <td class="text-end">{{ currency_symbol }}{{ "{:,.0f}".format(r.rent) }}</td>
           <td class="text-end">{{ currency_symbol }}{{ "{:,.0f}".format(r.expenses) }}</td>
-          <td class="text-end">{{ currency_symbol }}{{ "{:,.0f}".format(r.noi) }}</td>
+          <td class="text-end {{ 'text-danger' if r.noi < 0 else '' }}">{{ currency_symbol }}{{ "{:,.0f}".format(r.noi) }}</td>
           <td class="text-end">{{ currency_symbol }}{{ "{:,.0f}".format(r.debt_service) }}</td>
-          <td class="text-end">{{ currency_symbol }}{{ "{:,.0f}".format(r.cash_flow) }}</td>
+          <td class="text-end {{ 'text-danger' if r.cash_flow < 0 else 'text-success' }}">{{ currency_symbol }}{{ "{:,.0f}".format(r.cash_flow) }}</td>
           <td class="text-end">{{ currency_symbol }}{{ "{:,.0f}".format(r.equity) }}</td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
## Summary
- Remove newly added analyzer fields to revert to streamlined form
- Restore annual cash flow KPI and add conditional formatting for KPIs and yearly table
- Compute annual cash flow metric in backend for full results

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689686bacaf883288ca07a4dd38590e8