### PR TITLE
Integrate backend functionality from main

### DIFF
--- a/flask_app.py
+++ b/flask_app.py
@@ -1,238 +1,269 @@
-from __future__ import annotations
-
-from datetime import date
-from typing import Any, Dict, List, Tuple
-
-from flask import (
-    Flask,
-    render_template,
-    request,
-    redirect,
-    url_for,
-    send_file,
-    session,
-    flash,
-)
-
+from flask import Flask, render_template, request, jsonify, send_file
+import pandas as pd
+import numpy as np
+import plotly.express as px
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+import plotly.utils
+import json
+import math
 import io
-
-# ----- Optional, use real implementations if available -----
-try:
-    import utils as U  # your helper utilities
-except Exception:
-    U = None  # type: ignore
-
-try:
-    import financial_calculator as FC  # your compute engine
-except Exception:
-    FC = None  # type: ignore
-
-try:
-    import report_generator as RG  # PDF/Excel
-except Exception:
-    RG = None  # type: ignore
-# -----------------------------------------------------------
+import os
+import tempfile
+from financial_calculator import FinancialCalculator
+from utils import (
+    format_currency, format_percentage, format_currency_with_color,
+    format_percentage_with_color, export_to_excel, get_advanced_metrics
+)
+from report_generator import generate_pdf_report
 
 app = Flask(__name__)
-app.secret_key = "change-me"  # needed for session to keep last results
 
+def sanitize_json_data(data):
+    """
+    Recursively sanitize data to handle infinity and NaN values for JSON serialization
+    """
+    if isinstance(data, dict):
+        return {key: sanitize_json_data(value) for key, value in data.items()}
+    elif isinstance(data, list):
+        return [sanitize_json_data(item) for item in data]
+    elif isinstance(data, float):
+        if math.isnan(data) or math.isinf(data):
+            return None
+        return data
+    else:
+        return data
 
-def _currency_symbol(code: str) -> str:
-    if U and hasattr(U, "currency_symbol_for"):
-        try:
-            return U.currency_symbol_for(code)  # type: ignore[attr-defined]
-        except Exception:
-            pass
-    return {"SAR": "﷼", "USD": "$", "EUR": "€", "GBP": "£"}.get(code.upper(), "")
+@app.route('/')
+def index():
+    """Main dashboard page"""
+    return render_template('index.html')
 
+def clean_numeric_input(value):
+    """Clean numeric input by removing commas and converting to float"""
+    if isinstance(value, str):
+        return float(value.replace(',', ''))
+    return float(value)
 
-def _to_float(v: Any, default: float = 0.0) -> float:
+@app.route('/calculate', methods=['POST'])
+def calculate():
+    """Process calculation and return results"""
     try:
-        if v is None or v == "":
-            return default
-        return float(v)
-    except Exception:
-        return default
-
-
-def _compute_with_repo(payload: Dict[str, Any]) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
-    # Try your own compute functions first
-    if FC:
-        if hasattr(FC, "calculate_metrics"):
-            res = FC.calculate_metrics(payload)  # type: ignore[attr-defined]
-            if isinstance(res, tuple) and len(res) == 2:
-                return res  # type: ignore[return-value]
-            if isinstance(res, dict):
-                return res["metrics"], res["yearly"]  # type: ignore[index]
-        if hasattr(FC, "run"):
-            out = FC.run(payload)  # type: ignore[attr-defined]
-            return out["metrics"], out["yearly"]  # type: ignore[index]
-
-    # Fallback demo compute (UI always renders)
-    years = list(range(1, int(payload.get("exit_year", 10)) + 1))
-    annual_rent = float(payload.get("annual_rent", 0))
-    rent_g = float(payload.get("rent_growth", 0))
-    opex_pct = float(payload.get("opex_percent", 0))
-    insurance = float(payload.get("insurance", 0))
-    hoa = float(payload.get("hoa", 0))
-    debt_service = 50_000.0
-
-    rents = [annual_rent * ((1 + rent_g) ** (y - 1)) for y in years]
-    expenses = [r * opex_pct + insurance + hoa for r in rents]
-    cashflows = [r - e - debt_service for r, e in zip(rents, expenses)]
-    metrics = {
-        "monthly_cash_flow": (sum(cashflows) / len(cashflows) / 12) if cashflows else 0.0,
-        "cash_on_cash": 0.12,
-        "irr": 0.11,
-        "cap_rate": 0.065,
-        "dscr": 1.25,
-        "payback_years": 8.4,
-        "total_roi": 0.82,
-        "noi_y1": (rents[0] - expenses[0]) if rents else 0.0,
-    }
-    yearly = [
-        {
-            "year": y,
-            "rent": rents[y - 1],
-            "expenses": expenses[y - 1],
-            "noi": rents[y - 1] - expenses[y - 1],
-            "debt_service": debt_service,
-            "cash_flow": cashflows[y - 1],
-            "equity": 100_000 + 20_000 * (y - 1),
+        # Get form data
+        data = request.get_json()
+        print(f"Received data: {data}")  # Debug logging
+        
+        # Extract and clean parameters
+        property_price = clean_numeric_input(data.get('property_price', 0))
+        down_payment = clean_numeric_input(data.get('down_payment', 0))
+        loan_term = int(data.get('loan_term', 30))
+        interest_rate = clean_numeric_input(data.get('interest_rate', 0))
+        interest_type = data.get('interest_type', 'apr')
+        annual_rental_income = clean_numeric_input(data.get('base_monthly_rent', 0))  # This is actually annual income
+        base_monthly_rent = annual_rental_income / 12  # Convert to monthly
+        occupancy_rate = clean_numeric_input(data.get('occupancy_rate', 95))
+        rent_growth = clean_numeric_input(data.get('rent_growth', 0))
+        enhancement_costs = clean_numeric_input(data.get('enhancement_costs', 0))
+        hoa_fees_annual = clean_numeric_input(data.get('hoa_fees_annual', 0))
+        holding_period = int(data.get('holding_period', 10))
+        resale_value = clean_numeric_input(data.get('resale_value', 0))
+        
+        print(f"Processed values: price={property_price}, down={down_payment}, annual_rent={annual_rental_income}, monthly_rent={base_monthly_rent}")  # Debug logging
+        
+        # Create calculator instance
+        calc = FinancialCalculator(
+            property_price=property_price,
+            down_payment=down_payment,
+            loan_term=loan_term,
+            interest_rate=interest_rate,
+            interest_type=interest_type,
+            base_monthly_rent=base_monthly_rent,
+            occupancy_rate=occupancy_rate,
+            rent_growth=rent_growth,
+            enhancement_costs=enhancement_costs,
+            hoa_fees_annual=hoa_fees_annual,
+            holding_period=holding_period,
+            resale_value=resale_value
+        )
+        
+        # Get scenario analysis
+        scenarios = calc.get_scenario_analysis()
+        
+        # Get advanced metrics
+        advanced_metrics = get_advanced_metrics(calc)
+        
+        # Prepare charts data
+        charts_data = prepare_charts_data(calc, scenarios, advanced_metrics)
+        
+        # Format response
+        response = {
+            'success': True,
+            'scenarios': scenarios,
+            'advanced_metrics': advanced_metrics,
+            'charts': charts_data,
+            'calculator_data': {
+                'total_investment': calc.get_total_initial_investment(),
+                'loan_amount': calc.get_loan_amount(),
+                'monthly_payment': calc.get_monthly_payment(),
+                'total_interest': calc.get_total_interest(),
+                'break_even_years': advanced_metrics['payback_period'],
+                'occupancy_rate': calc.occupancy_rate,
+                'hoa_fees_annual': calc.hoa_fees_annual
+            }
         }
-        for y in years
-    ]
-    return metrics, yearly
+        
+        # Sanitize the response to handle infinity and NaN values
+        sanitized_response = sanitize_json_data(response)
+        
+        return jsonify(sanitized_response)
+        
+    except Exception as e:
+        import traceback
+        error_trace = traceback.format_exc()
+        print(f"Error in calculation: {str(e)}")
+        print(f"Full traceback:\n{error_trace}")
+        return jsonify({
+            'success': False,
+            'error': str(e)
+        }), 400
 
+def prepare_charts_data(calc, scenarios, advanced_metrics):
+    """Prepare chart data for frontend"""
+    
+    # KPI Cards data
+    kpi_data = {
+        'monthly_cash_flow': scenarios['base']['monthly_cash_flow'],
+        'annual_roi': scenarios['base']['roi'],
+        'total_investment': calc.get_total_initial_investment(),
+        'break_even_years': advanced_metrics['payback_period']
+    }
+    
+    # Cash Flow Performance Chart (Area Chart)
+    years = list(range(1, calc.holding_period + 1))
+    cash_flow_data = {
+        'years': years,
+        'scenarios': {}
+    }
+    
+    for scenario_key, scenario_name in [('conservative', 'Conservative'), ('base', 'Base'), ('optimistic', 'Optimistic')]:
+        schedule = scenarios[scenario_key]['cash_flow_schedule']
+        cumulative = []
+        total = 0
+        for cf in schedule:
+            total += cf
+            cumulative.append(total)
+        cash_flow_data['scenarios'][scenario_name] = cumulative
+    
+    # Investment Breakdown (Donut Chart)
+    investment_breakdown = {
+        'labels': ['Down Payment', 'Enhancement Costs', 'Loan Amount'],
+        'values': [calc.down_payment, calc.enhancement_costs, calc.get_loan_amount()],
+        'colors': ['#4285F4', '#34A853', '#FBBC04']
+    }
+    
+    # ROI Comparison (Bar Chart)
+    roi_comparison = {
+        'labels': ['Conservative', 'Base', 'Optimistic'],
+        'values': [scenarios['conservative']['roi'], scenarios['base']['roi'], scenarios['optimistic']['roi']],
+        'colors': ['#6C757D', '#4285F4', '#34A853']
+    }
+    
+    return {
+        'kpi_data': kpi_data,
+        'cash_flow_data': cash_flow_data,
+        'investment_breakdown': investment_breakdown,
+        'roi_comparison': roi_comparison,
+        'break_even_amount': calc.get_total_initial_investment()
+    }
 
-@app.route("/")
-def landing():
-    return render_template("landing.html")
-
-
-@app.route("/analyzer", methods=["GET"])
-def analyzer():
-    return render_template("analyzer_form.html")
-
-
-@app.route("/dashboard", methods=["POST"])
-def dashboard():
-    form = request.form
-
-    payload = dict(
-        currency=form.get("currency", "SAR"),
-        purchase_price=_to_float(form.get("purchase_price")),
-        down_payment=_to_float(form.get("down_payment")),
-        closing_costs=_to_float(form.get("closing_costs")),
-        interest_rate=_to_float(form.get("interest_rate")) / 100.0,
-        loan_years=int(_to_float(form.get("loan_years"), 0)) or 0,
-        annual_rent=_to_float(form.get("annual_rent")),
-        rent_growth=_to_float(form.get("rent_growth")) / 100.0,
-        vacancy_rate=_to_float(form.get("vacancy_rate")) / 100.0,
-        opex_percent=_to_float(form.get("opex_percent")) / 100.0,
-        insurance=_to_float(form.get("insurance")),
-        hoa=_to_float(form.get("hoa")),
-        rehab_cost=_to_float(form.get("rehab_cost")),
-        exit_year=int(_to_float(form.get("exit_year"), 10)) or 10,
-        exit_cap_rate=_to_float(form.get("exit_cap_rate")) / 100.0,
-    )
-
-    metrics, yearly = _compute_with_repo(payload)
-
-    years = [row.get("year") for row in yearly]
-    rents = [float(row.get("rent", 0)) for row in yearly]
-    expenses = [float(row.get("expenses", 0)) for row in yearly]
-    cashflows = [float(row.get("cash_flow", 0)) for row in yearly]
-
-    results = dict(
-        as_of=date.today().isoformat(),
-        currency_symbol=_currency_symbol(payload["currency"]),
-        metrics=metrics,
-        yearly=yearly,
-        years=years,
-        rents=rents,
-        expenses=expenses,
-        cashflows=cashflows,
-        payload=payload,
-    )
-
-    session["last_results"] = results
-    return render_template(
-        "dashboard.html",
-        as_of=results["as_of"],
-        currency_symbol=results["currency_symbol"],
-        metrics=results["metrics"],
-        yearly=results["yearly"],
-        years=results["years"],
-        rents=results["rents"],
-        expenses=results["expenses"],
-        cashflows=results["cashflows"],
-    )
-
-
-@app.route("/export/pdf")
-def export_pdf():
-    results = session.get("last_results")
-    if not results:
-        flash("Run an analysis first.")
-        return redirect(url_for("landing"))
-
-    if RG and hasattr(RG, "generate_pdf"):
-        try:
-            pdf_bytes = RG.generate_pdf(results)  # type: ignore[attr-defined]
-            return send_file(
-                io.BytesIO(pdf_bytes),
-                mimetype="application/pdf",
-                as_attachment=True,
-                download_name="RealEstateAnalyzer.pdf",
-            )
-        except Exception as e:
-            flash(f"PDF export failed: {e}")
-            return redirect(url_for("landing"))
-
-    from reportlab.lib.pagesizes import A4
-    from reportlab.pdfgen import canvas
-
-    buf = io.BytesIO()
-    c = canvas.Canvas(buf, pagesize=A4)
-    c.drawString(72, 800, "Real Estate Analyzer — PDF export placeholder")
-    c.drawString(72, 780, f"As of: {results['as_of']}")
-    c.drawString(72, 760, f"Cash-on-Cash: {results['metrics'].get('cash_on_cash', 0):.2%}")
-    c.save()
-    buf.seek(0)
-    return send_file(buf, mimetype="application/pdf", as_attachment=True, download_name="RealEstateAnalyzer.pdf")
-
-
-@app.route("/export/excel")
+@app.route('/export_excel', methods=['POST'])
 def export_excel():
-    results = session.get("last_results")
-    if not results:
-        flash("Run an analysis first.")
-        return redirect(url_for("landing"))
+    """Export analysis to Excel"""
+    try:
+        data = request.get_json()
+        
+        # Recreate calculator from data
+        calc = create_calculator_from_data(data)
+        scenarios = calc.get_scenario_analysis()
+        
+        # Create scenario DataFrame
+        scenario_data = []
+        for scenario_key, scenario_name in [('conservative', 'Conservative'), ('base', 'Base'), ('optimistic', 'Optimistic')]:
+            scenario_data.append({
+                'Scenario': scenario_name,
+                'Monthly Cash Flow': format_currency(scenarios[scenario_key]['monthly_cash_flow']),
+                'Annual Cash Flow': format_currency(scenarios[scenario_key]['annual_cash_flow']),
+                'Annual ROI': format_percentage(scenarios[scenario_key]['roi']),
+                'Monthly Rent': format_currency(scenarios[scenario_key]['monthly_rent']),
+                'IRR': format_percentage(scenarios[scenario_key]['irr']) if scenarios[scenario_key]['irr'] else 'N/A'
+            })
+        
+        scenario_df = pd.DataFrame(scenario_data)
+        
+        # Export to Excel
+        excel_buffer = export_to_excel(calc, scenarios, scenario_df)
+        
+        return send_file(
+            excel_buffer,
+            as_attachment=True,
+            download_name='investment_analysis.xlsx',
+            mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        )
+        
+    except Exception as e:
+        return jsonify({'error': str(e)}), 400
 
-    if RG and hasattr(RG, "generate_excel"):
-        try:
-            xlsx_bytes = RG.generate_excel(results)  # type: ignore[attr-defined]
-            return send_file(
-                io.BytesIO(xlsx_bytes),
-                mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                as_attachment=True,
-                download_name="RealEstateAnalyzer.xlsx",
-            )
-        except Exception as e:
-            flash(f"Excel export failed: {e}")
-            return redirect(url_for("landing"))
+@app.route('/export_pdf', methods=['POST'])
+def export_pdf():
+    """Export analysis to PDF"""
+    try:
+        data = request.get_json()
+        
+        # Recreate calculator from data
+        calc = create_calculator_from_data(data)
+        scenarios = calc.get_scenario_analysis()
+        advanced_metrics = get_advanced_metrics(calc)
+        
+        # Export to PDF using HTML + WeasyPrint
+        tmp_dir = tempfile.gettempdir()
+        pdf_path = os.path.join(tmp_dir, 'investment_analysis.pdf')
+        generate_pdf_report({
+            'calculator': calc,
+            'scenarios': scenarios,
+            'advanced_metrics': advanced_metrics
+        }, pdf_path)
 
-    import csv
+        return send_file(
+            pdf_path,
+            as_attachment=True,
+            download_name='investment_analysis.pdf',
+            mimetype='application/pdf'
+        )
+        
+    except Exception as e:
+        return jsonify({'error': str(e)}), 400
 
-    buf = io.StringIO()
-    writer = csv.writer(buf)
-    writer.writerow(["Year", "Rent", "Expenses", "NOI", "Debt Service", "Cash Flow", "Equity"])
-    for r in results["yearly"]:
-        writer.writerow([r["year"], r["rent"], r["expenses"], r["noi"], r["debt_service"], r["cash_flow"], r["equity"]])
-    data = io.BytesIO(buf.getvalue().encode("utf-8"))
-    return send_file(data, mimetype="text/csv", as_attachment=True, download_name="RealEstateAnalyzer.csv")
+def create_calculator_from_data(data):
+    """Helper function to recreate calculator from form data"""
+    # The form field 'base_monthly_rent' actually contains ANNUAL rental income
+    # despite its misleading name (legacy from when it was monthly)
+    annual_rental_income = clean_numeric_input(data.get('base_monthly_rent', 0))
+    base_monthly_rent = annual_rental_income / 12  # Convert annual to monthly
+    
+    return FinancialCalculator(
+        property_price=clean_numeric_input(data.get('property_price', 0)),
+        down_payment=clean_numeric_input(data.get('down_payment', 0)),
+        loan_term=int(data.get('loan_term', 30)),
+        interest_rate=clean_numeric_input(data.get('interest_rate', 0)),
+        interest_type=data.get('interest_type', 'apr'),
+        base_monthly_rent=base_monthly_rent,  # This is now correctly monthly
+        occupancy_rate=clean_numeric_input(data.get('occupancy_rate', 95)),
+        rent_growth=clean_numeric_input(data.get('rent_growth', 0)),
+        enhancement_costs=clean_numeric_input(data.get('enhancement_costs', 0)),
+        hoa_fees_annual=clean_numeric_input(data.get('hoa_fees_annual', 0)),
+        holding_period=int(data.get('holding_period', 10)),
+        resale_value=clean_numeric_input(data.get('resale_value', 0))
+    )
 
-
-if __name__ == "__main__":
-    app.run(debug=True)
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000, debug=True)


### PR DESCRIPTION
## Summary
- Replace placeholder Flask app with full-featured backend from main branch
- Include sanitization and calculation routes leveraging `FinancialCalculator`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689693767fd48328af0fb6bff335763c