### PR TITLE
Use theme colors for card headers

### DIFF
--- a/static/css/tdc.css
+++ b/static/css/tdc.css
@@ -9,5 +9,25 @@
   border-color: var(--tdc-primary);
 }
 
-.card { border-radius: 1rem; }
+.card{
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--bs-border-color);
+  box-shadow: 0 2px 8px rgba(0,0,0,.06);
+}
+
+.card-header{
+  background: var(--bs-body-bg) !important;
+  border-bottom: 1px solid var(--bs-border-color);
+}
+
+.card .table{
+  margin-bottom: 0;
+  --bs-table-bg: transparent;
+  --bs-table-border-color: var(--bs-border-color);
+}
+.card .table thead th{
+  border-bottom-width: 1px;
+}
+
 .navbar { backdrop-filter: blur(6px); }

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -45,7 +45,7 @@
 </div>
 
 <div class="card shadow-sm mb-3">
-  <div class="card-header bg-white"><strong>Scenario Analysis</strong></div>
+  <div class="card-header"><strong>Scenario Analysis</strong></div>
   <div class="table-responsive">
     <table class="table align-middle mb-0">
       <thead class="table-light">
@@ -77,40 +77,40 @@
 <div class="row g-3 mb-3">
   <div class="col-12 col-xl-6">
     <div class="card shadow-sm h-100">
-      <div class="card-header bg-white"><strong>ROI Comparison by Scenario</strong></div>
+      <div class="card-header"><strong>ROI Comparison by Scenario</strong></div>
       <div class="card-body"><div id="roiChart" style="height:360px;"></div></div>
     </div>
   </div>
   <div class="col-12 col-xl-6">
     <div class="card shadow-sm h-100">
-      <div class="card-header bg-white"><strong>Monthly Cash Flow Analysis</strong></div>
+      <div class="card-header"><strong>Monthly Cash Flow Analysis</strong></div>
       <div class="card-body"><div id="monthlyCashFlowChart" style="height:360px;"></div></div>
     </div>
   </div>
 </div>
 
 <div class="card shadow-sm mb-3">
-  <div class="card-header bg-white"><strong>Cash Flow Performance</strong></div>
+  <div class="card-header"><strong>Cash Flow Performance</strong></div>
   <div class="card-body"><div id="cashFlowPerformanceChart" style="height:360px;"></div></div>
 </div>
 
 <div class="row g-3">
   <div class="col-12 col-xl-8">
     <div class="card shadow-sm h-100">
-      <div class="card-header bg-white"><strong>Yearly Cash Flow</strong></div>
+      <div class="card-header"><strong>Yearly Cash Flow</strong></div>
       <div class="card-body"><div id="cashflowChart" style="height:360px;"></div></div>
     </div>
   </div>
   <div class="col-12 col-xl-4">
     <div class="card shadow-sm h-100">
-      <div class="card-header bg-white"><strong>Rent vs Expenses</strong></div>
+      <div class="card-header"><strong>Rent vs Expenses</strong></div>
       <div class="card-body"><div id="rentExpensesChart" style="height:360px;"></div></div>
     </div>
   </div>
 </div>
 
 <div class="card shadow-sm mt-3">
-  <div class="card-header bg-white d-flex justify-content-between align-items-center">
+  <div class="card-header d-flex justify-content-between align-items-center">
     <strong>Year-by-Year Summary</strong>
     <div class="d-flex gap-2">
       <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('export_pdf') }}">Export PDF</a>


### PR DESCRIPTION
## Summary
- let dashboard card headers inherit the theme instead of forcing white
- apply consistent card borders, overflow, and header styling via CSS

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896a827bf888328ae77606eea85df92