### PR TITLE
Reorder KPI cards and refine formatting

### DIFF
--- a/flask_app.py
+++ b/flask_app.py
@@ -86,15 +86,14 @@ def _compute_with_repo(payload: Dict[str, Any]) -> Tuple[Dict[str, Any], List[Di
 
     base = scenarios["base"]
     metrics = {
+        "total_investment": advanced["total_initial_investment"],
         "monthly_cash_flow": base["monthly_cash_flow"],
         "annual_cash_flow": base["annual_cash_flow"],
         "cash_on_cash": advanced["cash_on_cash_return"] / 100,
         "irr": (base["irr"] or 0) / 100,
-        "cap_rate": advanced["cap_rate"] / 100,
         "dscr": advanced["dscr"],
         "payback_years": advanced["payback_period"],
         "total_roi": base["roi"] / 100,
-        "noi_y1": base["net_income_schedule"][0] if base["net_income_schedule"] else 0,
     }
 
     return metrics, yearly, scenarios

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -9,33 +9,34 @@
 <!-- KPI cards -->
 <div class="row g-3 mb-3">
   {% for kpi in [
+    ('Total Investment', metrics.total_investment),
     ('Cash Flow / Mo', metrics.monthly_cash_flow),
     ('Cash Flow / Yr', metrics.annual_cash_flow),
     ('Cash-on-Cash', metrics.cash_on_cash),
     ('IRR', metrics.irr),
-    ('Cap Rate', metrics.cap_rate),
     ('DSCR', metrics.dscr),
     ('Payback (yrs)', metrics.payback_years),
     ('Total ROI', metrics.total_roi),
-    ('NOI (Y1)', metrics.noi_y1),
   ] %}
   <div class="col-12 col-sm-6 col-xl-3">
     <div class="card shadow-sm h-100">
       <div class="card-body">
         <div class="text-secondary">{{ kpi[0] }}</div>
         {% set cls = '' %}
-        {% if 'Cash Flow' in kpi[0] or 'NOI' in kpi[0] %}
+        {% if 'Cash Flow' in kpi[0] %}
           {% set cls = 'text-danger' if kpi[1] < 0 else 'text-success' %}
         {% elif kpi[0] == 'DSCR' %}
           {% set cls = 'text-danger' if kpi[1] < 1 else 'text-success' %}
         {% endif %}
         <div class="fs-4 fw-bold {{ cls }}">
-          {% if 'Rate' in kpi[0] or 'ROI' in kpi[0] or 'Cash-on-Cash' in kpi[0] or 'IRR' in kpi[0] %}
+          {% if kpi[0] in ['Cash-on-Cash', 'IRR', 'Total ROI'] %}
             {{ (kpi[1] * 100) | round(1) }}%
-          {% elif 'Payback' in kpi[0] %}
+          {% elif kpi[0] == 'DSCR' %}
+            {{ "{:.2f}".format(kpi[1]) }}
+          {% elif kpi[0] == 'Payback (yrs)' %}
             {{ kpi[1] | round(1) }}
           {% else %}
-            {{ currency_symbol }}{{ "{:,.0f}".format(kpi[1]) }}
+            {{ "{:,.0f}".format(kpi[1]) }}
           {% endif %}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Show KPI cards in specified order starting with Total Investment
- Add total investment metric in backend and drop unused KPIs
- Format KPI values without currency symbols and with proper precision

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896aceda9f88328aa7bc60eb836252e